### PR TITLE
Transform test results to normalize away an insignificant difference

### DIFF
--- a/tests/required/data-002.xml
+++ b/tests/required/data-002.xml
@@ -15,11 +15,15 @@
           <p:data href="../doc/textdata-utf8.txt" content-type="text/plain;charset=UTF-8"/>
         </p:input>
       </p:identity>
+
+      <p:string-replace match="/c:data/@content-type"
+                        replace="replace(., '&quot;', '')"/>
+
     </p:declare-step>
   </t:pipeline>
-  
+
   <t:output port='result'>
-    <c:data xmlns:c="http://www.w3.org/ns/xproc-step" content-type='text/plain; charset="utf-8"'>Toman a lesní panna
+    <c:data xmlns:c="http://www.w3.org/ns/xproc-step" content-type='text/plain; charset=utf-8'>Toman a lesní panna
 František Ladislav Čelakovský
 
 Večer před svatým Janem

--- a/tests/required/data-006.xml
+++ b/tests/required/data-006.xml
@@ -21,11 +21,14 @@
           <p:data href="../doc/textdata-utf8.txt" content-type="unknown/unknown;charset=UTF-8"/>
         </p:input>
       </p:identity>
+
+      <p:string-replace match="/c:data/@content-type"
+                        replace="replace(., '&quot;', '')"/>
     </p:declare-step>
   </t:pipeline>
   
   <t:output port='result'>
-    <c:data xmlns:c="http://www.w3.org/ns/xproc-step" content-type='text/plain; charset="utf-8"'>Toman a lesní panna
+    <c:data xmlns:c="http://www.w3.org/ns/xproc-step" content-type='text/plain; charset=utf-8'>Toman a lesní panna
 František Ladislav Čelakovský
 
 Večer před svatým Janem


### PR DESCRIPTION
Per our [discussion](http://www.w3.org/XML/XProc/2014/08/20-minutes#item06) at the XProc WG meeting of 20 Aug 2014, the use of quoted parameters is legal. However, the quoting is entirely optional for a parameter like "utf-8" that consists of a single token.

The patch proposed in this pull request simply normalizes away the difference. It makes no substantive change to the test.
